### PR TITLE
treat 2xx response codes as successful

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return array(
     'label' => 'OAT Oauth client',
     'description' => 'Extension to easily configure an OAuth client for OAT platform.',
     'license' => 'GPL-2.0',
-    'version' => '0.0.5',
+    'version' => '0.0.6',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=4.0.1',

--- a/model/provider/OauthProvider.php
+++ b/model/provider/OauthProvider.php
@@ -45,7 +45,7 @@ class OauthProvider extends GenericProvider
     {
         $response = $this->sendRequest($request);
 
-        if ($response->getStatusCode() !== 200 && $response->getStatusCode() !== 202) {
+        if (!preg_match('/2\d\d/', (string) $response->getStatusCode())) {
             throw new RequestException($response->getReasonPhrase(), $request, $response);
         }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -24,6 +24,6 @@ class Updater extends \common_ext_ExtensionUpdater
 {
     public function update($initialVersion)
     {
-        $this->skip('0.0.1', '0.0.5');
+        $this->skip('0.0.1', '0.0.6');
     }
 }


### PR DESCRIPTION
ACT's CAT server returns 201 response code and it causes an error.