### PR TITLE
Feature/tao 6219 get request header lower case

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,10 +26,10 @@ return array(
     'label' => 'OAT Oauth client',
     'description' => 'Extension to easily configure an OAuth client for OAT platform.',
     'license' => 'GPL-2.0',
-    'version' => '1.0.3',
+    'version' => '1.1.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'generis' => '>=4.0.1',
+        'generis' => '>=7.6.0',
         'tao' => '>=17.10.0',
         'taoPublishing' => '>=0.7.2',
     ),

--- a/model/Oauth2Service.php
+++ b/model/Oauth2Service.php
@@ -44,14 +44,13 @@ class Oauth2Service extends ConfigurableService
      */
     public function validate(\common_http_Request $request)
     {
-        $headers = $request->getHeaders();
-        $tokenService = $this->getTokenService();
 
-        if (!isset($headers['Authorization'])) {
+        $tokenService = $this->getTokenService();
+        $tokenHash    = $request->getHeaderValue('Authorization');
+
+        if (!$tokenHash) {
             throw new \common_http_InvalidSignatureException('invalid_client');
         }
-        $tokenHash = $headers['Authorization'];
-
         if (!$tokenService->verifyToken($tokenHash)) {
             throw new \common_http_InvalidSignatureException('invalid_client');
         }

--- a/model/bootstrap/Oauth2SessionBuilder.php
+++ b/model/bootstrap/Oauth2SessionBuilder.php
@@ -47,8 +47,8 @@ class Oauth2SessionBuilder implements SessionBuilder, ServiceLocatorAwareInterfa
      */
     public function isApplicable(\common_http_Request $request)
     {
-        $headers = $request->getHeaders();
-        return isset($headers['Authorization']) && strpos($headers['Authorization'], 'Basic') !== 0;
+        $authorizationHeader = $request->getHeaderValue('Authorization');
+        return $authorizationHeader != false && strpos($authorizationHeader, 'Basic') !== 0;
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -94,6 +94,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.1.0');
         }
 
-        $this->skip('0.1.0', '1.0.3');
+        $this->skip('0.1.0', '1.1.0');
     }
 }

--- a/test/model/Oauth2ServiceTest.php
+++ b/test/model/Oauth2ServiceTest.php
@@ -40,8 +40,8 @@ class Oauth2ServiceTest extends \PHPUnit_Framework_TestCase
 
         $request = $this->getMockBuilder(\common_http_Request::class)->disableOriginalConstructor()->getMock();
         $request
-            ->method('getHeaders')
-            ->willReturn($dataProvider['headers'] ?? null);
+            ->method('getHeaderValue')
+            ->willReturn($dataProvider['headers']['Authorization'] ?? null);
 
         $this->assertInstanceOf(Oauth2Service::class, $service->validate($request));
         $this->assertInstanceOf(core_kernel_classes_Resource::class, $service->getConsumer());
@@ -58,8 +58,8 @@ class Oauth2ServiceTest extends \PHPUnit_Framework_TestCase
 
         $request = $this->getMockBuilder(\common_http_Request::class)->disableOriginalConstructor()->getMock();
         $request
-            ->method('getHeaders')
-            ->willReturn($dataProvider['headers'] ?? null);
+            ->method('getHeaderValue')
+            ->willReturn($dataProvider['headers']['Authorization'] ?? null);
 
         $this->assertInstanceOf(Oauth2Service::class, $service->validate($request));
     }


### PR DESCRIPTION
Requires https://github.com/oat-sa/generis/pull/509

Allow to authenticate using the case insensitive `Authorization` (or `authorization`) HTTP header.
