### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'version' => '4.2.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'generis' => '>=7.6.0',
+        'generis' => '>=12.5.0',
         'tao' => '>=38.0.0'
     ),
     'acl' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return array(
     'label' => 'OAT Oauth client',
     'description' => 'Extension to easily configure an OAuth client for OAT platform.',
     'license' => 'GPL-2.0',
-    'version' => '4.2.0',
+    'version' => '5.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return array(
     'label' => 'OAT Oauth client',
     'description' => 'Extension to easily configure an OAuth client for OAT platform.',
     'license' => 'GPL-2.0',
-    'version' => '4.1.1',
+    'version' => '4.2.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=7.6.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -94,6 +94,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.1.0');
         }
 
-        $this->skip('0.1.0', '4.2.0');
+        $this->skip('0.1.0', '5.0.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -94,6 +94,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.1.0');
         }
 
-        $this->skip('0.1.0', '4.1.1');
+        $this->skip('0.1.0', '4.2.0');
     }
 }

--- a/test/model/OAuthClientTest.php
+++ b/test/model/OAuthClientTest.php
@@ -33,8 +33,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\TestCase;
 
-class OAuthClientTest extends \PHPUnit_Framework_TestCase
+class OAuthClientTest extends TestCase
 {
 
     /**

--- a/test/model/Oauth2ServiceTest.php
+++ b/test/model/Oauth2ServiceTest.php
@@ -26,8 +26,10 @@ use oat\taoOauth\model\storage\ConsumerStorage;
 use oat\taoOauth\model\token\TokenService;
 use oat\taoOauth\model\user\UserService;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\TestCase;
+use oat\generis\test\MockObject;
 
-class Oauth2ServiceTest extends \PHPUnit_Framework_TestCase
+class Oauth2ServiceTest extends TestCase
 {
 
     /**
@@ -232,7 +234,7 @@ class Oauth2ServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function mockResource()
     {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.
