### PR TITLE
Added option do define custom oAuth provider

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return array(
     'label' => 'OAT Oauth client',
     'description' => 'Extension to easily configure an OAuth client for OAT platform.',
     'license' => 'GPL-2.0',
-    'version' => '5.0.0',
+    'version' => '5.1.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/model/OAuthClient.php
+++ b/model/OAuthClient.php
@@ -109,7 +109,7 @@ class OAuthClient extends ConfigurableService implements ClientInterface
             throw new OauthException('No response from the server, connection cannot be established.', 0, $e);
         } catch (RequestException $e) {
             $response = $e->getResponse();
-            if ($response->getStatusCode() !== 401) {
+            if ($response!== null && $response->getStatusCode() !== 401) {
                 throw new OauthException($e->getMessage());
             }
         } catch (IdentityProviderException $e) {
@@ -118,7 +118,7 @@ class OAuthClient extends ConfigurableService implements ClientInterface
             throw new OauthException('Connection cannot be established.', 0, $e);
         }
 
-        if ($response && $response->getStatusCode() === 401) {
+        if ($response !== null && $response->getStatusCode() === 401) {
             if ($repeatIfUnauthorized) {
                 $this->requestAccessToken();
                 $params = json_decode($request->getBody()->__toString(), true);
@@ -131,7 +131,7 @@ class OAuthClient extends ConfigurableService implements ClientInterface
             }
         }
 
-        if ($response->getStatusCode() === 500) {
+        if ($response === null || $response->getStatusCode() === 500) {
             throw new OauthException('An internal error has occurred during server request.');
         }
 

--- a/model/OAuthClient.php
+++ b/model/OAuthClient.php
@@ -57,6 +57,9 @@ class OAuthClient extends ConfigurableService implements ClientInterface
     /** Additional token request parameter */
     const OPTION_TOKEN_REQUEST_PARAMS = 'tokenParameters';
 
+    /** Alternative Oauth provider */
+    const OPTION_OAUTH_PROVIDER = 'oauthProvider';
+
     /** @var AbstractProvider The provider to embed Oauth parameters */
     protected $provider;
 
@@ -106,6 +109,9 @@ class OAuthClient extends ConfigurableService implements ClientInterface
             throw new OauthException('No response from the server, connection cannot be established.', 0, $e);
         } catch (RequestException $e) {
             $response = $e->getResponse();
+            if ($response->getStatusCode() !== 401) {
+                throw new OauthException($e->getMessage());
+            }
         } catch (IdentityProviderException $e) {
             throw new OauthException('The provider response contains errors, connection cannot be established.', 0, $e);
         } catch (\Exception $e) {
@@ -125,8 +131,8 @@ class OAuthClient extends ConfigurableService implements ClientInterface
             }
         }
 
-        if ($response->getStatusCode() == 500) {
-            throw new OauthException('A internal error has occurred during server request.');
+        if ($response->getStatusCode() === 500) {
+            throw new OauthException('An internal error has occurred during server request.');
         }
 
         return $response;

--- a/model/provider/OauthProvider.php
+++ b/model/provider/OauthProvider.php
@@ -56,6 +56,7 @@ class OauthProvider extends GenericProvider
      * @param array $options
      * @return array|ResponseInterface
      * @throws OauthException
+     * @throws IdentityProviderException
      */
     public function getResponse(RequestInterface $request, $parse = true, $options = [])
     {

--- a/model/provider/ProviderFactory.php
+++ b/model/provider/ProviderFactory.php
@@ -22,6 +22,7 @@ namespace oat\taoOauth\model\provider;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use oat\oatbox\Configurable;
 use oat\taoOauth\model\exception\OauthException;
+use oat\taoOauth\model\OAuthClient;
 
 /**
  * Class ProviderFactory
@@ -32,7 +33,7 @@ use oat\taoOauth\model\exception\OauthException;
  */
 class ProviderFactory extends Configurable implements Provider
 {
-    
+
     /**
      * Create an instance of provider for Oauth connection.
      * A provider is required to follow Guzzle architecture, and usefull to manage all parameters required for an oauth connection.
@@ -44,6 +45,7 @@ class ProviderFactory extends Configurable implements Provider
     {
         try {
             $providerClass = $this->getProviderClass();
+            $this->logInfo('Using provider class: "'. $providerClass .'"');
             if (is_a($providerClass, AbstractProvider::class, true)) {
                 return new $providerClass($this->getFormattedOptions());
             }
@@ -60,6 +62,10 @@ class ProviderFactory extends Configurable implements Provider
      */
     protected function getProviderClass()
     {
+        if ($this->hasOption(OAuthClient::OPTION_OAUTH_PROVIDER)) {
+            return $this->getOption(OAuthClient::OPTION_OAUTH_PROVIDER);
+        }
+
         return OauthProvider::class;
     }
 
@@ -90,7 +96,7 @@ class ProviderFactory extends Configurable implements Provider
      */
     protected function validateOptions()
     {
-        $missing = array_diff_key(array_flip($this->getRequiredOptions()), $this->getOptions());
+        $missing = $this->getCleanOptions();
 
         if (!empty($missing)) {
             throw new \InvalidArgumentException(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -99,6 +99,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.1.0');
         }
 
-        $this->skip('0.1.0', '5.0.0');
+        $this->skip('0.1.0', '5.1.0');
     }
 }


### PR DESCRIPTION
In order to provide a way to override response handling an option has been added to set a custom oAuth provider. This is needed in order to display the final reports that we would receive from the Deliver Back-end

Related PR:

- [ ] https://github.com/oat-sa/extension-tao-deliver-connect/pull/43