### PR TITLE
Feature/uno 266 add scope paraemeter on oauth credentials

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return array(
     'label' => 'OAT Oauth client',
     'description' => 'Extension to easily configure an OAuth client for OAT platform.',
     'license' => 'GPL-2.0',
-    'version' => '5.2.0',
+    'version' => '5.2.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/model/provider/Provider.php
+++ b/model/provider/Provider.php
@@ -57,4 +57,7 @@ interface Provider
 
     /** @var string Code for authorization_code grant type */
     const CODE = 'code';
+
+    /** @var string Scopes definition */
+    const SCOPE = 'scope';
 }

--- a/model/storage/grant/ClientCredentialsType.php
+++ b/model/storage/grant/ClientCredentialsType.php
@@ -20,6 +20,8 @@
 
 namespace oat\taoOauth\model\storage\grant;
 
+use oat\taoOauth\model\provider\Provider;
+
 /**
  * Class ClientCredentialsType
  * @package oat\taoOauth\model\storage\grant
@@ -27,4 +29,17 @@ namespace oat\taoOauth\model\storage\grant;
 class ClientCredentialsType extends OauthCredentials
 {
     const NAME = 'client_credentials';
+
+    /**
+     * @return array
+     */
+    public function getProperties()
+    {
+        return array_merge(
+            parent::getProperties(),
+            [
+                Provider::SCOPE => !empty($this->properties[Provider::SCOPE]) ? $this->properties[Provider::SCOPE]: ''
+            ]
+        );
+    }
 }

--- a/model/storage/grant/ClientCredentialsType.php
+++ b/model/storage/grant/ClientCredentialsType.php
@@ -38,7 +38,7 @@ class ClientCredentialsType extends OauthCredentials
         return array_merge(
             parent::getProperties(),
             [
-                Provider::SCOPE => !empty($this->properties[Provider::SCOPE]) ? $this->properties[Provider::SCOPE]: ''
+                Provider::SCOPE => $this->properties[Provider::SCOPE] ?? ''
             ]
         );
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -99,6 +99,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.1.0');
         }
 
-        $this->skip('0.1.0', '5.2.0');
+        $this->skip('0.1.0', '5.2.1');
     }
 }

--- a/test/model/OAuthClientTest.php
+++ b/test/model/OAuthClientTest.php
@@ -37,6 +37,7 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use oat\generis\test\TestCase;
+use function FastRoute\TestFixtures\empty_options_cached;
 
 class OAuthClientTest extends TestCase
 {
@@ -48,6 +49,10 @@ class OAuthClientTest extends TestCase
     public function testRequest($dataProvider)
     {
         $uri = $this->getMockForAbstractClass(UriInterface::class);
+
+        if (!empty($dataProvider['exception'])) {
+            $this->expectException(OauthException::class);
+        }
 
         $this->assertInstanceOf(ResponseInterface::class, $this->getClient($dataProvider)->request('POST', $uri));
     }

--- a/test/model/Oauth2ServiceTest.php
+++ b/test/model/Oauth2ServiceTest.php
@@ -95,21 +95,21 @@ class Oauth2ServiceTest extends TestCase
     {
         $service = $this->getService([]);
 
-        $this->assertInternalType('string', $service->generateClientKey());
+        $this->assertIsString($service->generateClientKey());
     }
 
     public function testGenerateClientSecret()
     {
         $service = $this->getService([]);
 
-        $this->assertInternalType('string', $service->generateClientSecret('client_key'));
+        $this->assertIsString($service->generateClientSecret('client_key'));
     }
 
     public function testGetDefaultTokenUrl()
     {
         $service = $this->getService([]);
 
-        $this->assertInternalType('string', $service->getDefaultTokenUrl());
+        $this->assertIsString($service->getDefaultTokenUrl());
     }
 
     protected function getService($dataProvider)

--- a/test/model/Oauth2TypeTest.php
+++ b/test/model/Oauth2TypeTest.php
@@ -97,7 +97,7 @@ class Oauth2TypeTest extends TestCase
                         'client_secret' => 'client_secret',
                         'token_url' => 'token_url',
                         'token_type' => 'Bearer',
-                        'grant_type' => 'client_credentials'
+                        'grant_type' => 'client_credentials',
                     ],
                     'out' => [
                         'client_id' => 'client_id',
@@ -105,6 +105,7 @@ class Oauth2TypeTest extends TestCase
                         'token_url' => 'token_url',
                         'token_type' => 'Bearer',
                         'grant_type' => 'client_credentials',
+                        'scope'      => '',
                         'body' => null,
                         'headers' => null
                     ]
@@ -116,7 +117,8 @@ class Oauth2TypeTest extends TestCase
                         'client_id' => 'client_id',
                         'client_secret' => 'client_secret',
                         'token_url' => 'token_url',
-                        'grant_type' => 'client_credentials'
+                        'grant_type' => 'client_credentials',
+                        'scope'      => 'read-scope'
                     ],
                     'out' => [
                         'client_id' => 'client_id',
@@ -124,6 +126,7 @@ class Oauth2TypeTest extends TestCase
                         'token_url' => 'token_url',
                         'grant_type' => 'client_credentials',
                         'token_type' => '',
+                        'scope'      => 'read-scope',
                         'body' => null,
                         'headers' => null
                     ]


### PR DESCRIPTION
This patch adds `scope` parameter on valid/accepted list of parameter
for configuration of OAuth authentication using grant_type: client_credentials

It's required by this [PR.](https://github.com/oat-sa/extension-tao-udir/pull/62) 