### PR TITLE
fix: prevent using auth provider with old options

### DIFF
--- a/model/OAuthClient.php
+++ b/model/OAuthClient.php
@@ -324,9 +324,7 @@ class OAuthClient extends ConfigurableService implements ClientInterface
      */
     protected function getProvider()
     {
-        if (!$this->provider) {
-            $this->provider = (new ProviderFactory($this->getOptions()))->build();
-        }
+        $this->provider = (new ProviderFactory($this->getOptions()))->build();
 
         return $this->provider;
     }


### PR DESCRIPTION
This is a draft fix of https://oat-sa.atlassian.net/browse/AUT-881
As been found:
- we update HTTP client options: https://github.com/oat-sa/extension-tao-deliver-connect/blob/master/model/api/RestApiClient.php#L97 
- But using a previously created instance of the client: https://github.com/oat-sa/extension-tao-deliver-connect/blob/master/model/api/RestApiClient.php#L87 
- Then in the client instead of building a provider with new options we using a previously stored provider which is always exist
 https://github.com/oat-sa/extension-tao-oauth/blob/master/model/OAuthClient.php#L327

Why it exists, and moreover it contains an options from other tenant? 
As far as I see the HTTP client instance is stored in subServices which is probably shared between queue tasks:
https://github.com/oat-sa/generis/blob/master/common/oatbox/service/ConfigurableService.php#L71

#### How to test:
Publish a delivery with different tenants one by one several times:
- `Customer 1 - Deliver - LTI 1.1 - .env` / `Customer 1 - Deliver - LTI 1.3 - .env`
- `QA Deliver - LTI 1.3 - .env`

Wait while publishing finished
Validate that no failed tasks occurred in task queue list