### PR TITLE
fix: allow cache to store proper token in case cache ininvalid JSON

### DIFF
--- a/model/storage/ConsumerStorage.php
+++ b/model/storage/ConsumerStorage.php
@@ -20,6 +20,10 @@
 
 namespace oat\taoOauth\model\storage;
 
+use common_Exception;
+use common_exception_NotFound;
+use core_kernel_classes_Resource;
+use core_kernel_persistence_Exception;
 use League\OAuth2\Client\Token\AccessToken;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
@@ -30,32 +34,32 @@ class ConsumerStorage extends ConfigurableService
 {
     use OntologyAwareTrait;
 
-    const SERVICE_ID = 'taoOauth/consumerStorage';
+    public const SERVICE_ID = 'taoOauth/consumerStorage';
 
-    const DEFAULT_PERSISTENCE = 'default';
-    const DEFAULT_CACHE = 'cache';
-    const OPTION_PERSISTENCE = 'persistence';
-    const OPTION_CACHE = 'cache';
+    public const DEFAULT_PERSISTENCE = 'default';
+    public const DEFAULT_CACHE = 'cache';
+    public const OPTION_PERSISTENCE = 'persistence';
+    public const OPTION_CACHE = 'cache';
 
-    const CONSUMER_CLASS = DataStore::CLASS_URI_OAUTH_CONSUMER;
-    const CONSUMER_CLIENT_KEY = DataStore::PROPERTY_OAUTH_KEY;
-    const CONSUMER_CLIENT_SECRET = DataStore::PROPERTY_OAUTH_SECRET;
-    const CONSUMER_CALLBACK_URL = DataStore::PROPERTY_OAUTH_CALLBACK;
+    public const CONSUMER_CLASS = DataStore::CLASS_URI_OAUTH_CONSUMER;
+    public const CONSUMER_CLIENT_KEY = DataStore::PROPERTY_OAUTH_KEY;
+    public const CONSUMER_CLIENT_SECRET = DataStore::PROPERTY_OAUTH_SECRET;
+    public const CONSUMER_CALLBACK_URL = DataStore::PROPERTY_OAUTH_CALLBACK;
 
-    const CONSUMER_TOKEN = 'http://www.taotesting.com/ontologies/taooauth.rdf#Token';
-    const CONSUMER_TOKEN_HASH = 'http://www.taotesting.com/ontologies/taooauth.rdf#TokenHash';
-    const CONSUMER_TOKEN_URL = 'http://www.taotesting.com/ontologies/taooauth.rdf#TokenUrl';
-    const CONSUMER_TOKEN_TYPE = 'http://www.taotesting.com/ontologies/taooauth.rdf#TokenType';
-    const CONSUMER_TOKEN_GRANT_TYPE = 'http://www.taotesting.com/ontologies/taooauth.rdf#GrantType';
+    public const CONSUMER_TOKEN = 'http://www.taotesting.com/ontologies/taooauth.rdf#Token';
+    public const CONSUMER_TOKEN_HASH = 'http://www.taotesting.com/ontologies/taooauth.rdf#TokenHash';
+    public const CONSUMER_TOKEN_URL = 'http://www.taotesting.com/ontologies/taooauth.rdf#TokenUrl';
+    public const CONSUMER_TOKEN_TYPE = 'http://www.taotesting.com/ontologies/taooauth.rdf#TokenType';
+    public const CONSUMER_TOKEN_GRANT_TYPE = 'http://www.taotesting.com/ontologies/taooauth.rdf#GrantType';
 
     /**
      * Register a token to a consumer resource
      *
-     * @param \core_kernel_classes_Resource $consumer
+     * @param core_kernel_classes_Resource $consumer
      * @param AccessToken $token
-     * @throws \common_Exception
+     * @throws common_Exception
      */
-    public function setConsumerToken(\core_kernel_classes_Resource $consumer, AccessToken $token)
+    public function setConsumerToken(core_kernel_classes_Resource $consumer, AccessToken $token)
     {
         $consumer->removePropertyValues($this->getProperty(self::CONSUMER_TOKEN));
         $consumer->removePropertyValues($this->getProperty(self::CONSUMER_TOKEN_HASH));
@@ -73,11 +77,11 @@ class ConsumerStorage extends ConfigurableService
      *
      * Fetch token from cache if exists, otherwise set it
      *
-     * @param $tokenHash
+     * @param string $tokenHash
      * @return AccessToken
-     * @throws \common_Exception
-     * @throws \common_exception_NotFound
-     * @throws \core_kernel_persistence_Exception
+     * @throws common_Exception
+     * @throws common_exception_NotFound
+     * @throws core_kernel_persistence_Exception
      */
     public function getToken($tokenHash)
     {
@@ -113,7 +117,7 @@ class ConsumerStorage extends ConfigurableService
 
             $this->logError($errorMessage);
 
-            throw new \common_exception_NotFound($errorMessage);
+            throw new common_exception_NotFound($errorMessage);
         }
 
         $token = new AccessToken($decodedToken);
@@ -128,7 +132,7 @@ class ConsumerStorage extends ConfigurableService
      * @param $clientKey
      * @param $clientSecret
      * @return mixed
-     * @throws \common_exception_NotFound
+     * @throws common_exception_NotFound
      */
     public function getConsumer($clientKey, $clientSecret)
     {
@@ -143,7 +147,7 @@ class ConsumerStorage extends ConfigurableService
         if (count($consumers) == 1) {
             return reset($consumers);
         } else {
-            throw new \common_exception_NotFound('invalid_client');
+            throw new common_exception_NotFound('invalid_client');
         }
     }
 
@@ -151,8 +155,8 @@ class ConsumerStorage extends ConfigurableService
      * Get an oauth consumer by token hash
      *
      * @param $hash
-     * @return \core_kernel_classes_Resource
-     * @throws \common_exception_NotFound
+     * @return core_kernel_classes_Resource
+     * @throws common_exception_NotFound
      */
     public function getConsumerByTokenHash($hash)
     {
@@ -164,7 +168,7 @@ class ConsumerStorage extends ConfigurableService
         if (count($consumers) == 1) {
             return reset($consumers);
         } else {
-            throw new \common_exception_NotFound('Consumer does not exist.');
+            throw new common_exception_NotFound('Consumer does not exist.');
         }
     }
 
@@ -174,7 +178,7 @@ class ConsumerStorage extends ConfigurableService
      * @param $key
      * @param $secret
      * @param $tokenUrl
-     * @return \core_kernel_classes_Resource
+     * @return core_kernel_classes_Resource
      */
     public function createConsumer($key, $secret, $tokenUrl)
     {
@@ -206,7 +210,7 @@ class ConsumerStorage extends ConfigurableService
             array('like' => false, 'recursive' => true)
         );
 
-        /** @var \core_kernel_classes_Resource $consumer */
+        /** @var core_kernel_classes_Resource $consumer */
         foreach ($consumers as $consumer) {
             $consumer->delete();
         }

--- a/model/storage/ConsumerStorage.php
+++ b/model/storage/ConsumerStorage.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2018-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 namespace oat\taoOauth\model\storage;

--- a/test/model/storage/ConsumerStorageTest.php
+++ b/test/model/storage/ConsumerStorageTest.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 declare(strict_types=1);

--- a/test/model/storage/ConsumerStorageTest.php
+++ b/test/model/storage/ConsumerStorageTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoOauth\test\model\storage;
+
+use common_exception_NotFound;
+use common_persistence_KeyValuePersistence;
+use core_kernel_classes_Class;
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use League\OAuth2\Client\Token\AccessToken;
+use oat\generis\model\data\Ontology;
+use oat\generis\persistence\PersistenceManager;
+use oat\generis\test\TestCase;
+use oat\oatbox\log\LoggerService;
+use oat\taoOauth\model\storage\ConsumerStorage;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ConsumerStorageTest extends TestCase
+{
+    private const VALID_JSON_TOKEN = '{"access_token": "abc123", "expires": 1645172996}';
+    private const VALID_ARRAY_TOKEN = [
+        'access_token' => 'abc123',
+        'expires' => '1645172996',
+    ];
+
+    /** @var ConsumerStorage */
+    private $subject;
+
+    /** @var PersistenceManager|MockObject */
+    private $persistenceManager;
+
+    /** @var common_persistence_KeyValuePersistence|MockObject */
+    private $cachePersistence;
+
+    /** @var Ontology|MockObject */
+    private $ontology;
+
+    /** @var core_kernel_classes_Class|MockObject */
+    private $consumerClass;
+
+    /** @var core_kernel_classes_Resource|MockObject */
+    private $consumerResource;
+
+    /** @var core_kernel_classes_Property|MockObject */
+    private $tokenProperty;
+
+    public function setUp(): void
+    {
+        $this->ontology = $this->createMock(Ontology::class);
+        $this->logger = $this->createMock(LoggerService::class);
+        $this->persistenceManager = $this->createMock(PersistenceManager::class);
+        $this->cachePersistence = $this->createMock(common_persistence_KeyValuePersistence::class);
+
+        $this->consumerClass = $this->createMock(core_kernel_classes_Class::class);
+        $this->consumerResource = $this->createMock(core_kernel_classes_Resource::class);
+        $this->tokenProperty = $this->createMock(core_kernel_classes_Property::class);
+
+        $this->persistenceManager
+            ->method('getPersistenceById')
+            ->willReturn($this->cachePersistence);
+
+        $this->subject = new ConsumerStorage();
+        $this->subject->setServiceManager(
+            $this->getServiceLocatorMock(
+                [
+                    PersistenceManager::SERVICE_ID => $this->persistenceManager,
+                    Ontology::SERVICE_ID => $this->ontology,
+                    LoggerService::SERVICE_ID => $this->logger,
+                ]
+            )
+        );
+    }
+
+    public function testGetValidTokenFromCache(): void
+    {
+        $this->cachePersistence
+            ->expects($this->once())
+            ->method('exists')
+            ->willReturn(true);
+
+        $this->cachePersistence
+            ->expects($this->once())
+            ->method('get')
+            ->with('abc123')
+            ->willReturn(self::VALID_JSON_TOKEN);
+
+        $this->assertEquals(
+            new AccessToken(self::VALID_ARRAY_TOKEN),
+            $this->subject->getToken('abc123')
+        );
+    }
+
+    public function testGetInvalidTokenFromCacheWillRestoreTokenFromDataBase(): void
+    {
+        $this->cachePersistence
+            ->expects($this->once())
+            ->method('exists')
+            ->willReturn(true);
+
+        $this->cachePersistence
+            ->expects($this->once())
+            ->method('get')
+            ->with('abc123')
+            ->willReturn('invalid {json}');
+
+        $this->cachePersistence
+            ->expects($this->once())
+            ->method('set');
+
+        $this->ontology
+            ->expects($this->once())
+            ->method('getClass')
+            ->with(ConsumerStorage::CONSUMER_CLASS)
+            ->willReturn($this->consumerClass);
+
+        $this->ontology
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with(ConsumerStorage::CONSUMER_TOKEN)
+            ->willReturn($this->tokenProperty);
+
+        $this->consumerClass
+            ->expects($this->once())
+            ->method('searchInstances')
+            ->willReturn(
+                [
+                    $this->consumerResource,
+                ]
+            );
+
+        $this->consumerResource
+            ->expects($this->once())
+            ->method('getOnePropertyValue')
+            ->with($this->tokenProperty)
+            ->willReturn(self::VALID_JSON_TOKEN);
+
+        $this->assertEquals(
+            new AccessToken(self::VALID_ARRAY_TOKEN),
+            $this->subject->getToken('abc123')
+        );
+    }
+
+    public function testGetInvalidTokenFromDataBaseWillThrowException(): void
+    {
+        $this->cachePersistence
+            ->expects($this->once())
+            ->method('exists')
+            ->willReturn(false);
+
+        $this->ontology
+            ->expects($this->once())
+            ->method('getClass')
+            ->with(ConsumerStorage::CONSUMER_CLASS)
+            ->willReturn($this->consumerClass);
+
+        $this->ontology
+            ->expects($this->once())
+            ->method('getProperty')
+            ->with(ConsumerStorage::CONSUMER_TOKEN)
+            ->willReturn($this->tokenProperty);
+
+        $this->consumerClass
+            ->expects($this->once())
+            ->method('searchInstances')
+            ->willReturn(
+                [
+                    $this->consumerResource,
+                ]
+            );
+
+        $this->consumerResource
+            ->expects($this->once())
+            ->method('getOnePropertyValue')
+            ->with($this->tokenProperty)
+            ->willReturn('invalid {json}');
+
+        $this->expectException(common_exception_NotFound::class);
+        $this->expectExceptionMessage('The token abc123... contains an invalid JSON: Syntax error');
+
+        $this->subject->getToken('abc123');
+    }
+}


### PR DESCRIPTION
Task https://oat-sa.atlassian.net/browse/ADF-959

In case an invalid token JSON was saved in the cache, we get correct one from DB and store it in the cache again.