### PR TITLE
fix: update core dependecies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "league/oauth2-client" : "^2.0",
         "oat-sa/generis" : ">=14.0.0",
-        "oat-sa/tao-core" : ">=47.0.0"
+        "oat-sa/tao-core" : ">=54.21.0"
     },
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
It is causing following error in TAO:

Argument 1 passed to oat\taoOauth\model\provider\OauthProvider::parseResponse() must implement interface Psr\Http\Message\ResponseInterface, array given, called in /var/www/html/tao/vendor/league/oauth2-client/src/Provider/AbstractProvider.php on line 724