### PR TITLE
Fix OauthProvider::getResponse

### DIFF
--- a/model/provider/OauthProvider.php
+++ b/model/provider/OauthProvider.php
@@ -58,7 +58,7 @@ class OauthProvider extends GenericProvider
      * @throws OauthException
      * @throws IdentityProviderException
      */
-    public function getResponse(RequestInterface $request, $parse = true, $options = [])
+    public function getResponse(RequestInterface $request, $parse = false, $options = [])
     {
         $response = $this->sendRequest($request, $options);
 


### PR DESCRIPTION
When using new league/oauth2-client version we were causing fatal error when providing array instead of Response Interface